### PR TITLE
Pass AWS_* env through turbo to deploy tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -27,10 +27,16 @@
       ]
     },
     "deploy:dev": {
-      "cache": false
+      "cache": false,
+      "passThroughEnv": [
+        "AWS_*"
+      ]
     },
     "deploy:prod": {
-      "cache": false
+      "cache": false,
+      "passThroughEnv": [
+        "AWS_*"
+      ]
     }
   }
 }


### PR DESCRIPTION
Fixes the failed master deploy after #46: turbo 2's strict env mode strips undeclared env vars from task processes, so the OIDC credentials exported by `configure-aws-credentials` never reached `serverless deploy` (`AWS provider credentials not found`). `passThroughEnv: ["AWS_*"]` on both deploy tasks fixes it. Local deploys never noticed because they use `~/.aws`, not env vars.