### PR TITLE
Fix turbo filter for web prod deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,4 +56,4 @@ jobs:
       # need src/env/prod.ts, which is deliberately not a CI secret)
       - name: "web: Deploy to prod environment"
         if: github.ref == 'refs/heads/master'
-        run: npx turbo deploy:prod --filter web
+        run: npx turbo deploy:prod --filter @odir/web


### PR DESCRIPTION
The web prod deploy step failed with `No package found with name 'web' in workspace` — the workspace package is `@odir/web`. This filter came verbatim from the previously-commented deploy block, which predates the `@odir/` package rename and was never exercised.